### PR TITLE
Fix missing libgssapi_krb5.so.2 in Flatpak builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ linuxdeploy_plugins = [
 [tool.briefcase.app.kemonodownloader.linux.flatpak]
 flatpak_runtime = "org.kde.Platform"
 flatpak_runtime_version = "6.7"
+flatpak_base = "com.riverbankcomputing.PyQt.BaseApp"
+flatpak_base_version = "6.7"
 flatpak_sdk = "org.kde.Sdk"
 
 [tool.briefcase.app.kemonodownloader.windows]


### PR DESCRIPTION
# Fix missing libgssapi_krb5.so.2 in Flatpak builds

## Description

Requires https://github.com/beeware/briefcase-linux-flatpak-template/pull/64 to be merged in first! In the meantime, you can use my template:

```
[tool.briefcase.app.kemonodownloader.linux.flatpak]
flatpak_runtime = "org.kde.Platform"
flatpak_runtime_version = "6.7"
flatpak_base = "com.riverbankcomputing.PyQt.BaseApp"
flatpak_base_version = "6.7"
flatpak_sdk = "org.kde.Sdk"
template = "https://github.com/limdingwen/briefcase-linux-flatpak-template/"
```

Before this commit, running `briefcase build linux flatpak` would work, but running it would cause a missing `libgssapi_krb5.so.2` error and an instant crash.

One of the ways to fix this is by using https://github.com/flathub/com.riverbankcomputing.PyQt.BaseApp/ as the base, which this commit does.

## Type of Change

- \[X\] Bug fix (non-breaking change that fixes an issue)
- \[ \] New feature (non-breaking change that adds functionality)
- \[ \] Breaking change (fix or feature that changes existing functionality)
- \[ \] Documentation update
- \[ \] Security fix
- \[ \] Other (please describe):

## How Has This Been Tested?

Tested on Linux, Fedora Silverblue. Flatpak building must be done on the host machine, not in a Toolbox. Python 3.13.7. `briefcase build linux flatpak`.

## Checklist

- \[X\] My code follows the Contributing Guidelines and Code of Conduct.
- \[X\] My changes adhere to PEP 8 style guidelines.
- \[X\] I have tested my changes thoroughly using Briefcase on at least one supported platform.
- \[X\] I have updated the documentation (e.g., `README.md`, `SUPPORT.md`, in-app Help tab) if necessary.
- \[X\] My changes do not introduce new dependencies without prior discussion.
- \[X\] My changes respect the intellectual property rights and terms of service of Kemono.su and related platforms, as outlined in the README.
- \[X\] I have not included unverified links or promotional content.
- \[X\] For security-related changes, I have followed the Security Policy.

## Additional Notes

Additional work needs to be done to publish a pre-built Flatpak.

---

**Note**: Maintainers may request changes or additional information. Please respond promptly to feedback to ensure a smooth review process.