### PR TITLE
Add home folder permissions for Flatpak

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ linuxdeploy_plugins = [
 ]
 
 [tool.briefcase.app.kemonodownloader.linux.flatpak]
+finish_arg."filesystem=home" = true
 flatpak_runtime = "org.kde.Platform"
 flatpak_runtime_version = "6.7"
 flatpak_sdk = "org.kde.Sdk"


### PR DESCRIPTION
# Add home folder permissions for Flatpak

## Description

It's likely that the user wants Kemono Downloader to download into their downloads folder, not the Flatpak's own sandbox filesystem.

Note that the default downloads folder is still in the sandbox, but this commit allows them to select their own downloads folder (and potentially a folder used by a previous instance of Kemono Downloader) without a temporary folder being created.

## Type of Change

- \[X\] Bug fix (non-breaking change that fixes an issue)
- \[ \] New feature (non-breaking change that adds functionality)
- \[ \] Breaking change (fix or feature that changes existing functionality)
- \[ \] Documentation update
- \[ \] Security fix
- \[ \] Other (please describe):

## How Has This Been Tested?

Tested on Linux, Fedora Silverblue. Flatpak building must be done on the host machine, not in a Toolbox. Python 3.13.7. `briefcase build linux flatpak`.

## Checklist

- \[X\] My code follows the Contributing Guidelines and Code of Conduct.
- \[X\] My changes adhere to PEP 8 style guidelines.
- \[X\] I have tested my changes thoroughly using Briefcase on at least one supported platform.
- \[X\] I have updated the documentation (e.g., `README.md`, `SUPPORT.md`, in-app Help tab) if necessary.
- \[X\] My changes do not introduce new dependencies without prior discussion.
- \[X\] My changes respect the intellectual property rights and terms of service of Kemono.su and related platforms, as outlined in the README.
- \[X\] I have not included unverified links or promotional content.
- \[X\] For security-related changes, I have followed the Security Policy.

## Screenshots or Logs (if applicable)

<img width="995" height="875" alt="image" src="https://github.com/user-attachments/assets/fed6c036-fe62-43af-b8e6-33b965d5f877" />

Running as a Flatpak \^

---

**Note**: Maintainers may request changes or additional information. Please respond promptly to feedback to ensure a smooth review process.