### PR TITLE
Improved failed/succeeded files error handling and counting

### DIFF
--- a/src/kemonodownloader/creator_downloader.py
+++ b/src/kemonodownloader/creator_downloader.py
@@ -1811,19 +1811,24 @@ class CreatorDownloaderTab(QWidget):
     def update_file_completion(self, file_index, file_url, success):
         """Update file completion status and check overall progress."""
         with self.completed_files_lock, self.failed_files_lock:
-            if file_url not in self.completed_files and file_url not in self.failed_files:
-                if success:
+            if success:
+                if file_url not in self.completed_files:
                     self.completed_files.add(file_url)
+                # Remove from failed_files if it was there before
+                if file_url in self.failed_files:
+                    del self.failed_files[file_url]
                 self.append_log_to_console(translate("log_debug", translate("file_completed", file_url, len(self.completed_files), self.total_files_to_download)), "INFO")
             else:
-                # Find the CreatorDownloadThread to get the error message
-                error_message = "Unknown error"
-                for thread in self.active_threads:
-                    if isinstance(thread, CreatorDownloadThread):
-                        error_message = thread.failed_files.get(file_url, "Unknown error")
-                        break
-                self.failed_files[file_url] = error_message
-                self.append_log_to_console(translate("log_debug", translate("file_failed", file_url, len(self.failed_files))), "INFO")
+                # Only mark as failed if not already completed
+                if file_url not in self.completed_files:
+                    # Find the CreatorDownloadThread to get the error message
+                    error_message = "Unknown error"
+                    for thread in self.active_threads:
+                        if isinstance(thread, CreatorDownloadThread):
+                            error_message = thread.failed_files.get(file_url, "Unknown error")
+                            break
+                    self.failed_files[file_url] = error_message
+                    self.append_log_to_console(translate("log_debug", translate("file_failed", file_url, len(self.failed_files))), "INFO")
             self.update_overall_progress()
             # Check if all files have been attempted (successful or failed)
             if self.total_files_to_download > 0 and len(self.completed_files) + len(self.failed_files) >= self.total_files_to_download:


### PR DESCRIPTION
## Description

Fixed a scenario where if some files failed, if they will be downloaded successfully in the next run, they remain in the failed_files list counting as errors, even though correctly fetched.

## Type of Change

- \[X] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

Describe how you tested your changes, including:

- Tested windows builds, python 3.10
- Run the creator downloader, with some failed files (ex. large archives), wait for finish. Run it again without restarting waiting for previously failed files to complete successfully. Verify that the log doesn't print any failed downloads when all the files were successfully completed. Previously, the downloader would report previously failed files as still "failed" even though he downloaded them just fine.

## Checklist

- \[X] My code follows the Contributing Guidelines and Code of Conduct.
- \[X] My changes adhere to PEP 8 style guidelines.
- \[X] I have tested my changes thoroughly using Briefcase on at least one supported platform.
- \[X] I have updated the documentation (e.g., `README.md`, `SUPPORT.md`, in-app Help tab) if necessary.
- \[X] My changes do not introduce new dependencies without prior discussion.
- \[X] My changes respect the intellectual property rights and terms of service of Kemono.su and related platforms, as outlined in the README.
- \[X] I have not included unverified links or promotional content.
- \[X] For security-related changes, I have followed the Security Policy.

---