### PR TITLE
Add download size validation to fix incomplete downloads, fix post downloader threading

### DIFF
--- a/src/kemonodownloader/creator_downloader.py
+++ b/src/kemonodownloader/creator_downloader.py
@@ -801,6 +801,21 @@ class CreatorDownloadThread(QThread):
 
                     file_handle.close()
                     file_handle = None
+
+                    # Validate downloaded size matches content-length
+                    if file_size > 0 and downloaded_size != file_size:
+                        error_msg = translate("size_mismatch_error", downloaded_size, file_size, file_url)
+                        self.log.emit(translate("log_warning", error_msg), "WARNING")
+                        # Delete incomplete file
+                        if os.path.exists(full_path):
+                            try:
+                                os.remove(full_path)
+                                self.log.emit(translate("log_info", translate("deleted_incomplete_file", full_path)), "INFO")
+                            except OSError as e:
+                                self.log.emit(translate("log_error", translate("failed_to_delete_incomplete_file", full_path, str(e))), "ERROR")
+                        # Raise exception to trigger retry
+                        raise Exception(f"Size mismatch: downloaded {downloaded_size} bytes, expected {file_size} bytes")
+
                     with open(full_path, 'rb') as f:
                         file_hash = hashlib.md5(f.read()).hexdigest()
                     with self.file_hashes_lock:

--- a/src/kemonodownloader/kd_language.py
+++ b/src/kemonodownloader/kd_language.py
@@ -823,6 +823,24 @@ class KDLanguage:
                 "korean": "{1}번의 시도 후 {0} 다운로드 실패: {2}",
                 "chinese-simplified": "尝试 {1} 次后下载 {0} 失败: {2}"
             },
+            "size_mismatch_error": {
+                "english": "Downloaded size ({0} bytes) does not match expected size ({1} bytes) for {2}",
+                "japanese": "ダウンロードサイズ（{0}バイト）が予期されるサイズ（{1}バイト）と一致しません：{2}",
+                "korean": "다운로드된 크기({0}바이트)가 예상 크기({1}바이트)와 일치하지 않습니다: {2}",
+                "chinese-simplified": "下载大小（{0}字节）与预期大小（{1}字节）不匹配：{2}"
+            },
+            "deleted_incomplete_file": {
+                "english": "Deleted incomplete file: {0}",
+                "japanese": "不完全なファイルを削除しました：{0}",
+                "korean": "불완전한 파일 삭제됨: {0}",
+                "chinese-simplified": "已删除不完整的文件：{0}"
+            },
+            "failed_to_delete_incomplete_file": {
+                "english": "Failed to delete incomplete file {0}: {1}",
+                "japanese": "不完全なファイル{0}の削除に失敗しました：{1}",
+                "korean": "불완전한 파일 {0} 삭제 실패: {1}",
+                "chinese-simplified": "删除不完整的文件 {0} 失败：{1}"
+            },
             "retry_countdown": {
                 "english": "Trying again in {0}...",
                 "japanese": "{0}秒後に再試行します...",


### PR DESCRIPTION
## Description

- Added download size validation to fix incomplete downloads, which were being recognized as successful.

- Added omitted thread locks in the post downloader


## Related Issue

Fixes https://github.com/VoxDroid/KemonoDownloader/issues/46

## Type of Change

- \[X] Bug fix (non-breaking change that fixes an issue)
- \[X] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

Describe how you tested your changes, including:

Python 3.10 on windows briefcase builds

## Checklist

- \[X] My code follows the Contributing Guidelines and Code of Conduct.
- \[X] My changes adhere to PEP 8 style guidelines.
- \[X] I have tested my changes thoroughly using Briefcase on at least one supported platform.
- \[X] I have updated the documentation (e.g., `README.md`, `SUPPORT.md`, in-app Help tab) if necessary.
- \[X] My changes do not introduce new dependencies without prior discussion.
- \[X] My changes respect the intellectual property rights and terms of service of Kemono.su and related platforms, as outlined in the README.
- \[X] I have not included unverified links or promotional content.
- \[X] For security-related changes, I have followed the Security Policy.

## Screenshots or Logs (if applicable)
Example output after the fix:

`[WARNING] Downloaded size (4226527 bytes) does not match expected size (5760265 bytes) for [REDACTED]?f=2fjZkLRZ28CIQIndG6rGzery.jpeg
[INFO] Deleted incomplete file: S:/kemono/download/k2\Kemono Downloader\Downloads\fanbox\9172824_ヨルハ二号B型_2B\3_2fjZkLRZ28CIQIndG6rGzery.jpeg

[WARNING] Download failed for [REDACTED]?f=2fjZkLRZ28CIQIndG6rGzery.jpeg, attempt 1/8: Size mismatch: downloaded 4226527 bytes, expected 5760265 bytes

[INFO] Trying again in 3...

[WARNING] Downloaded size (5750239 bytes) does not match expected size (5762068 bytes) for [REDACTED]?f=vsEX6HcULf3QypNBahZokOhH.jpeg

[INFO] Deleted incomplete file: S:/kemono/download/k2\Kemono Downloader\Downloads\fanbox\9172824_ヨルハ二号B型_2B\4_vsEX6HcULf3QypNBahZokOhH.jpeg

[WARNING] Download failed for [REDACTED]?f=vsEX6HcULf3QypNBahZokOhH.jpeg, attempt 1/8: Size mismatch: downloaded 5750239 bytes, expected 5762068 bytes

[INFO] Trying again in 3...
[INFO] Trying again in 2...
[INFO] Trying again in 2...
[INFO] Trying again in 1...
[INFO] Trying again in 1...

[DEBUG] File completed: [REDACTED]?f=2fjZkLRZ28CIQIndG6rGzery.jpeg, Total completed: 8/9

[DEBUG] Overall progress updated: 8/9 files, 88%

[INFO] Successfully downloaded: S:/kemono/download/k2\Kemono Downloader\Downloads\fanbox\9172824_ヨルハ二号B型_2B\3_2fjZkLRZ28CIQIndG6rGzery.jpeg
[DEBUG] File completed: [REDACTED]?f=vsEX6HcULf3QypNBahZokOhH.jpeg, Total completed: 9/9

[DEBUG] Overall progress updated: 9/9 files, 100%`


---

**Note**: Maintainers may request changes or additional information. Please respond promptly to feedback to ensure a smooth review process.