### PR TITLE
Texts, links and JFIF supports

### DIFF
--- a/src/kemonodownloader/creator_downloader.py
+++ b/src/kemonodownloader/creator_downloader.py
@@ -453,7 +453,7 @@ class FilePreparationThread(QThread):
             if 'f=' not in file_url and file_name:
                 file_url += f"?f={file_name}"
             self.log.emit(translate("log_debug", translate("checking_main_file", file_name, file_ext)), "INFO")
-            if '.jpg' in allowed_extensions and file_ext in ['.jpg', '.jpeg']:
+            if '.jpg' in allowed_extensions and file_ext in ['.jpg', '.jpeg', '.jfif']:
                 self.log.emit(translate("log_debug", translate("added_main_file", file_name)), "INFO")
                 files_to_download.append((file_name, file_url))
             elif file_ext in allowed_extensions:
@@ -471,7 +471,7 @@ class FilePreparationThread(QThread):
                     if 'f=' not in attachment_url and attachment_name:
                         attachment_url += f"?f={attachment_name}"
                     self.log.emit(translate("log_debug", translate("checking_attachment", attachment_name, attachment_ext)), "INFO")
-                    if '.jpg' in allowed_extensions and attachment_ext in ['.jpg', '.jpeg']:
+                    if '.jpg' in allowed_extensions and attachment_ext in ['.jpg', '.jpeg', '.jfif']:
                         self.log.emit(translate("log_debug", translate("added_attachment", attachment_name)), "INFO")
                         files_to_download.append((attachment_name, attachment_url))
                     elif attachment_ext in allowed_extensions:
@@ -486,7 +486,7 @@ class FilePreparationThread(QThread):
                 img_ext = os.path.splitext(img_url)[1].lower()
                 img_name = os.path.basename(img_url)
                 self.log.emit(translate("log_debug", translate("checking_content_image", img_name, img_ext)), "INFO")
-                if '.jpg' in allowed_extensions and img_ext in ['.jpg', '.jpeg']:
+                if '.jpg' in allowed_extensions and img_ext in ['.jpg', '.jpeg', '.jfif']:
                     self.log.emit(translate("log_debug", translate("added_content_image", img_name)), "INFO")
                     files_to_download.append((img_name, img_url))
                 elif img_ext in allowed_extensions:
@@ -1317,7 +1317,7 @@ class CreatorDownloaderTab(QWidget):
         creator_ext_layout.setHorizontalSpacing(20)
         creator_ext_layout.setVerticalSpacing(10)
         self.creator_ext_checks = {
-            '.jpg': QCheckBox("JPG/JPEG"),
+            '.jpg': QCheckBox("JPG/JPEG/JFIF"),
             '.png': QCheckBox("PNG"),
             '.zip': QCheckBox("ZIP"),
             '.mp4': QCheckBox("MP4"),

--- a/src/kemonodownloader/post_downloader.py
+++ b/src/kemonodownloader/post_downloader.py
@@ -102,7 +102,7 @@ class PreviewThread(QThread):
         cache_path = os.path.join(self.cache_dir, cache_key)
         
         if os.path.exists(cache_path):
-            if ext in ['.jpg', '.jpeg', '.png']:
+            if ext in ['.jpg', '.jpeg', '.png', '.jfif']:
                 pixmap = QPixmap()
                 if pixmap.load(cache_path):
                     self.preview_ready.emit(self.url, pixmap)
@@ -128,7 +128,7 @@ class PreviewThread(QThread):
                         progress = int((self.downloaded_size / self.total_size) * 100)
                         self.progress.emit(min(progress, 100))
             
-            if ext in ['.jpg', '.jpeg', '.png']:
+            if ext in ['.jpg', '.jpeg', '.png', '.jfif']:
                 pixmap = QPixmap()
                 if not pixmap.loadFromData(downloaded_data):
                     self.error.emit(f"{translate('error_loading_image')}: {self.url}: {translate('invalid_image_data')}")
@@ -254,7 +254,7 @@ class MediaPreviewModal(QDialog):
     def start_preview(self):
         ext = os.path.splitext(self.media_url.lower())[1]
 
-        if ext in ['.jpg', '.jpeg', '.png', '.gif', '.webp']:
+        if ext in ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.jfif']:
             self.preview_thread = PreviewThread(self.media_url, self.cache_dir)
             self.preview_thread.preview_ready.connect(self.display_image)
             self.preview_thread.progress.connect(self.update_progress)
@@ -616,7 +616,7 @@ class PostDetectionThread(QThread):
     def detect_files(self, post):
         detected_files = []
         allowed_extensions = ['.jpg', '.jpeg', '.png', '.gif', '.zip', '.mp4', '.pdf', '.7z', 
-                              '.mp3', '.wav', '.rar', '.mov', '.docx', '.psd', '.clip', '.jpe', '.webp']
+                              '.mp3', '.wav', '.rar', '.mov', '.docx', '.psd', '.clip', '.jpe', '.webp', '.jfif']
 
         def get_effective_extension(file_path, file_name):
             name_ext = os.path.splitext(file_name)[1].lower()
@@ -1430,8 +1430,8 @@ class PostDownloaderTab(QWidget):
             '.pdf': QCheckBox("PDF"), '.7z': QCheckBox("7Z"),
             '.mp3': QCheckBox("MP3"), '.wav': QCheckBox("WAV"), '.rar': QCheckBox("RAR"),
             '.mov': QCheckBox("MOV"), '.docx': QCheckBox("DOCX"), '.psd': QCheckBox("PSD"), 
-            '.clip': QCheckBox("CLIP"), '.jpe':QCheckBox("JPE"), '.webp':QCheckBox("WEBP"),
-            '.txt': QCheckBox("TXT")
+            '.clip': QCheckBox("CLIP"), '.jpe':QCheckBox("JPE"), '.jfif': QCheckBox("JFIF"),
+            '.webp':QCheckBox("WEBP"), '.txt': QCheckBox("TXT")
         }
         for i, (ext, check) in enumerate(self.post_filter_checks.items()):
             check.setChecked(True)
@@ -2322,7 +2322,7 @@ class PostDownloaderTab(QWidget):
         if self.current_preview_url:
             ext = os.path.splitext(self.current_preview_url.lower())[1]
             unsupported_extensions = ['.zip', '.psd', '.docx', '.7z', '.rar', '.clip','jpe']
-            supported_extensions = ['.jpg', '.jpeg', '.png', '.gif', '.mp4', '.mov', '.mp3', '.wav', '.webp']
+            supported_extensions = ['.jpg', '.jpeg', '.png', '.gif', '.mp4', '.mov', '.mp3', '.wav', '.webp', '.jfif']
 
             if ext in unsupported_extensions:
                 self.append_log_to_console(translate("log_warning", translate("preview_not_supported", ext, self.current_preview_url)), "WARNING")


### PR DESCRIPTION
# Pull Request

Thank you for contributing to KemonoDownloader! Please complete this template to help us review your changes efficiently. Ensure your submission complies with our Contributing Guidelines, Code of Conduct, and Security Policy. Do not include unverified links or promotional content, as they will be considered spam.

## Description
App  is now capable of scraping embedded links and texts in the posts and save them in a .txt file.
JFIF support is added as a separate file in Post Downloader, and JPG/JPEG group in the Creator Downloader.


## Related Issue

#41 
 
## Type of Change

- \[ \] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- Windows 11
- Python 3.13
- Briefcase run windows
- Downloading a post with embedded links, jfif files, texts and combinations.x

## Checklist

- \[ \] My code follows the Contributing Guidelines and Code of Conduct.
- \[ \] My changes adhere to PEP 8 style guidelines.
- \[ \] I have tested my changes thoroughly using Briefcase on at least one supported platform.
- \[ \] I have updated the documentation (e.g., `README.md`, `SUPPORT.md`, in-app Help tab) if necessary.
- \[ \] My changes do not introduce new dependencies without prior discussion.
- \[ \] My changes respect the intellectual property rights and terms of service of Kemono.su and related platforms, as outlined in the README.
- \[ \] I have not included unverified links or promotional content.
- \[ \] For security-related changes, I have followed the Security Policy.

## Screenshots or Logs (if applicable)

If your changes affect the UI or produce specific outputs, attach screenshots or logs to demonstrate the results.

## Additional Notes

Provide any other context, such as challenges faced, trade-offs made, or future work needed.

---

**Note**: Maintainers may request changes or additional information. Please respond promptly to feedback to ensure a smooth review process.