### PR TITLE
Version 5.11.1 - Support dynamic pawchive domains

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,17 @@
 # Kemono Downloader Release Notes
 
+## v5.11.1 (05 July 2026)
+**fix: dynamic pawchive domain suffix resolution and documentation refresh**
+
+- Replace hardcoded `pawchive.st` handling with dynamic `pawchive.<suffix>` support.
+  The downloader now derives the active pawchive suffix from the domain list configuration and builds file hosts dynamically (`file.pawchive.<suffix>`), avoiding breakage when pawchive domains rotate.
+
+- Improve pawchive file URL normalization for dynamic domains.
+  URL cleanup now rewrites direct pawchive links to the correct file host based on the active suffix and still enforces `/data/` path normalization for compatibility.
+
+- Update tests and release documentation for v5.11.1.
+  Refreshed pawchive URL tests to be suffix-agnostic and updated version metadata/docs for this patch release.
+
 ## v5.11.0 (17 June 2026)
 **feat: dynamic domain configuration and pawchive.st support**
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
     <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey" alt="Platforms">
   </a>
   <a href="https://github.com/VoxDroid/KemonoDownloader/releases">
-    <img src="https://img.shields.io/badge/version-v5.11.0-brightgreen" alt="Version">
+    <img src="https://img.shields.io/badge/version-v5.11.1-brightgreen" alt="Version">
   </a>
   <a>
     <img src="https://img.shields.io/github/v/release/VoxDroid/KemonoDownloader?label=Latest%20Release" alt="Latest Release">
@@ -87,19 +87,19 @@
 
 <hr style="border: 1px dashed #4A6B9A; margin: 20px 0;">
 
-Welcome to **$\color{#546e7a}{\sf{\text{KemonoDownloader}}}$**, a versatile Python-based desktop application built with PyQt6, designed to download content from [Kemono.cr](https://kemono.cr), [Coomer.st](https://coomer.st), and [Pawchive.st](https://pawchive.st). This tool enables users to archive individual posts or entire creator profiles from services like Patreon, Fanbox, and more, supporting a wide range of file types with customizable settings and advanced features.
+Welcome to **$\color{#546e7a}{\sf{\text{KemonoDownloader}}}$**, a versatile Python-based desktop application built with PyQt6, designed to download content from [Kemono.cr](https://kemono.cr), [Coomer.st](https://coomer.st), and [Pawchive.pw](https://pawchive.pw). This tool enables users to archive individual posts or entire creator profiles from services like Patreon, Fanbox, and more, supporting a wide range of file types with customizable settings and advanced features.
 
 ## $\color{#546e7a}{\sf{\text{Important Notices}}}$ <a name="important-notices"></a>
 
 ### $\color{#90a4ae}{\sf{\text{Disclaimer}}}$ <a name="disclaimer"></a>
 
-KemonoDownloader is a tool designed for personal and educational use only, to assist users in downloading content from Kemono.cr, Coomer.st, and Pawchive.st. The maintainers of this project **do not condone or support the unauthorized distribution of copyrighted material**. Users are solely responsible for ensuring they have the legal right to access and download content from Kemono.cr, Coomer.st, and Pawchive.st, and for complying with all applicable laws, as well as the terms of service of the original platforms from which the content originates (e.g., Patreon, Pixiv Fanbox, Gumroad).
+KemonoDownloader is a tool designed for personal and educational use only, to assist users in downloading content from Kemono.cr, Coomer.st, and Pawchive.pw. The maintainers of this project **do not condone or support the unauthorized distribution of copyrighted material**. Users are solely responsible for ensuring they have the legal right to access and download content from Kemono.cr, Coomer.st, and Pawchive.pw, and for complying with all applicable laws, as well as the terms of service of the original platforms from which the content originates (e.g., Patreon, Pixiv Fanbox, Gumroad).
 
 **Misuse of this tool to infringe on creators’ rights, violate copyright laws, or breach terms of service is strictly prohibited.** The maintainers are not liable for any misuse of KemonoDownloader or any consequences arising from its use, including but not limited to legal action, financial loss, or damage to third parties.
 
 ### $\color{#90a4ae}{\sf{\text{Ethical Use Guidelines}}}$ <a name="ethical-use-guidelines"></a>
 
-KemonoDownloader interacts with content from Kemono.cr, Coomer.st, and Pawchive.st, which may include material originally posted on paywalled platforms like Patreon, Pixiv Fanbox, and Gumroad. Many creators on these platforms rely on paid subscriptions for their livelihood. Downloading and redistributing their content without permission can harm their ability to continue creating.
+KemonoDownloader interacts with content from Kemono.cr, Coomer.st, and Pawchive.pw, which may include material originally posted on paywalled platforms like Patreon, Pixiv Fanbox, and Gumroad. Many creators on these platforms rely on paid subscriptions for their livelihood. Downloading and redistributing their content without permission can harm their ability to continue creating.
 
 We strongly encourage users to:
 - Use KemonoDownloader responsibly and only for content you have the legal right to access.
@@ -108,19 +108,19 @@ We strongly encourage users to:
 
 ### $\color{#90a4ae}{\sf{\text{Risks and Limitations}}}$ <a name="risks-and-limitations"></a>
 
-- **Legal Risks**: Downloading content from Kemono.cr, Coomer.st, and Pawchive.st may violate copyright laws or the terms of service of the original platforms. Users assume all legal risks associated with using this tool.
-- **Dependency on Kemono.cr, Coomer.st, and Pawchive.st**: KemonoDownloader relies on Kemono.cr, Coomer.st, and Pawchive.st, which have a history of inconsistent updates and downtime. If these sites become unavailable, this tool will lose its functionality.
-- **Rate Limits and Errors**: Kemono.cr, Coomer.st, and Pawchive.st may impose rate limits or other restrictions that affect download performance. The maintainers cannot guarantee uninterrupted access to these sites' content.
+- **Legal Risks**: Downloading content from Kemono.cr, Coomer.st, and Pawchive.pw may violate copyright laws or the terms of service of the original platforms. Users assume all legal risks associated with using this tool.
+- **Dependency on Kemono.cr, Coomer.st, and Pawchive.pw**: KemonoDownloader relies on Kemono.cr, Coomer.st, and Pawchive.pw, which have a history of inconsistent updates and downtime. If these sites become unavailable, this tool will lose its functionality.
+- **Rate Limits and Errors**: Kemono.cr, Coomer.st, and Pawchive.pw may impose rate limits or other restrictions that affect download performance. The maintainers cannot guarantee uninterrupted access to these sites' content.
 
 ### $\color{#90a4ae}{\sf{\text{Site Availability Status}}}$ <a name="site-availability-status"></a>
 
-As of **June 17, 2026**, the media download servers for **Kemono.cr** and **Coomer.st** are currently unavailable or not being updated. To ensure continued functionality, **Pawchive.st** has been added as an alternative source for content.
+As of **June 17, 2026**, the media download servers for **Kemono.cr** and **Coomer.st** are currently unavailable or not being updated. To ensure continued functionality, **Pawchive.pw** has been added as an alternative source for content.
 
 | Site | Status | Last Checked |
 | :--- | :---: | :--- |
-| [Kemono.cr](https://kemono.cr) | 🔴 Unavailable | June 17, 2026 |
-| [Coomer.st](https://coomer.st) | 🔴 Unavailable | June 17, 2026 |
-| [Pawchive.st](https://pawchive.st) | 🟢 Available | June 17, 2026 |
+| [Kemono.cr](https://kemono.cr) | 🔴 Unavailable | July, 5 2026 |
+| [Coomer.st](https://coomer.st) | 🔴 Unavailable | July, 5 2026 |
+| [Pawchive.pw](https://pawchive.pw) | 🟢 Available | July, 5 2026 |
 
 *Note: Status reflects the availability of media download servers. Front-end availability may vary.*
 
@@ -161,7 +161,7 @@ We are committed to fostering a welcoming and respectful community around Kemono
 
 ## $\color{#546e7a}{\sf{\text{Features}}}$ <a name="features"></a>
 
-KemonoDownloader offers a comprehensive set of features designed to efficiently download and manage content from Kemono.cr, Coomer.st, and Pawchive.st. Below is a detailed breakdown organized by category.
+KemonoDownloader offers a comprehensive set of features designed to efficiently download and manage content from Kemono.cr, Coomer.st, and Pawchive.pw. Below is a detailed breakdown organized by category.
 
 ### $\color{#90a4ae}{\sf{\text{Downloading Capabilities}}}$
 
@@ -244,7 +244,7 @@ KemonoDownloader offers a comprehensive set of features designed to efficiently 
 |---------|-------------|
 | **Local Storage** | All data stored locally with user-specified paths |
 | **No Data Collection** | No transmission of user data or download history |
-| **HTTPS Only** | Secure connections to Kemono.cr, Coomer.st, and Pawchive.st APIs |
+| **HTTPS Only** | Secure connections to Kemono.cr, Coomer.st, and Pawchive.pw APIs |
 | **Ethical Design** | Promotes legal and responsible content access |
 
 ## $\color{#546e7a}{\sf{\text{Browser Extension}}}$ <a name="browser-extension"></a>
@@ -340,18 +340,18 @@ Support ongoing development and get access here: **[Ko-fi Binaries Page](https:/
    - **macOS**: `briefcase run macos`
    - **Linux**: `briefcase run linux`
    - **General**: `briefcase dev` *(Recommended)*
-   - **Note**: An internet connection is required to fetch content from Kemono.cr, Coomer.st, and Pawchive.st.
+   - **Note**: An internet connection is required to fetch content from Kemono.cr, Coomer.st, and Pawchive.pw.
 
 ## $\color{#546e7a}{\sf{\text{Usage}}}$ <a name="usage"></a>
 Upon launching, you’ll see an introductory screen with a "Launch" button. Click it to enter the main interface, featuring four tabs: **Post Downloader**, **Creator Downloader**, **Settings**, and **Help**. The in-app Help tab contains a comprehensive user manual.
 
 ### $\color{#90a4ae}{\sf{\text{Getting Started}}}$ <a name="getting-started"></a>
 - The application creates default directories (`Downloads`, `Cache`, `Other Files`) in the specified save location.
-- Ensure an active internet connection to access Kemono.cr, Coomer.st, and Pawchive.st content.
+- Ensure an active internet connection to access Kemono.cr, Coomer.st, and Pawchive.pw content.
 - Explore the Help tab for detailed instructions and troubleshooting tips.
 
 ### $\color{#90a4ae}{\sf{\text{Post Downloader Tab}}}$ <a name="post-downloader-tab"></a>
-- **Purpose**: Download files from individual Kemono.cr, Coomer.st, and Pawchive.st posts.
+- **Purpose**: Download files from individual Kemono.cr, Coomer.st, and Pawchive.pw posts.
 - **How to Use**:
   1. Enter a post URL (e.g., `https://kemono.cr/patreon/user/123456789/post/123456789` or `https://coomer.st/patreon/user/123456789/post/123456789`) in the "Enter post URL" field.
   2. Click "Add to Queue" to add it to the list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.briefcase]
 project_name = "Kemono Downloader"
 bundle = "com.voxdroid"
-version = "5.11.0"
+version = "5.11.1"
 url = "https://github.com/VoxDroid/KemonoDownloader"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/src/kemonodownloader/app.py
+++ b/src/kemonodownloader/app.py
@@ -32,7 +32,7 @@ from kemonodownloader.post_downloader import PostDownloaderTab
 
 warnings.filterwarnings("ignore", category=MarkupResemblesLocatorWarning)
 
-CURRENT_VERSION = "5.11.0"
+CURRENT_VERSION = "5.11.1"
 GITHUB_REPO = "VoxDroid/KemonoDownloader"
 
 # Available Google Fonts bundled with the app

--- a/src/kemonodownloader/domain_config.py
+++ b/src/kemonodownloader/domain_config.py
@@ -52,7 +52,7 @@ _LOCAL_DOMAIN_FILE = os.path.join(_HERE, "..", "..", "assets", "config", "domain
 _FALLBACK_DOMAINS: List[str] = [
     "kemono.cr",
     "coomer.st",
-    "pawchive.st",
+    "pawchive.pw",
 ]
 
 # ---------------------------------------------------------------------------
@@ -121,11 +121,16 @@ def get_domains() -> List[str]:
     return _domains_cache
 
 
+def _is_pawchive_domain(domain: str) -> bool:
+    """Return True when *domain* is a pawchive domain (any suffix)."""
+    return domain.startswith("pawchive.")
+
+
 def _build_config(domain: str) -> Dict[str, str]:
     """Build a domain config dict for the given domain string."""
-    # Special case for file download servers, e.g. pawchive.st -> file.pawchive.st
-    if domain == "pawchive.st":
-        file_base_url = "https://file.pawchive.st"
+    # Special case for file download servers, e.g. pawchive.<suffix> -> file.pawchive.<suffix>
+    if _is_pawchive_domain(domain):
+        file_base_url = f"https://file.{domain}"
     else:
         file_base_url = f"https://{domain}"
 
@@ -141,28 +146,32 @@ def _build_config(domain: str) -> Dict[str, str]:
 def clean_file_url(file_url: str, domain_config: Dict[str, str]) -> str:
     """Ensure that the file URL uses the correct download server.
 
-    For example, pawchive.st uses file.pawchive.st for file downloads.
+    For example, pawchive.<suffix> uses file.pawchive.<suffix> for file downloads.
     """
-    from urllib.parse import urljoin
+    from urllib.parse import urljoin, urlparse, urlunparse
 
     base = domain_config.get("base_url", "")
     file_base_url = domain_config.get("file_base_url") or base
     full_url = urljoin(file_base_url, file_url)
+    domain = str(domain_config.get("domain", "") or "")
 
-    # Rewrite pawchive.st URLs if they got mapped to the main domain
-    if "://pawchive.st" in full_url:
-        full_url = full_url.replace("://pawchive.st", "://file.pawchive.st")
-
-    # For pawchive.st, the file path must contain /data/
-    if "pawchive.st" in full_url:
-        from urllib.parse import urlparse, urlunparse
-
+    if _is_pawchive_domain(domain):
         parsed = urlparse(full_url)
+        pawchive_file_host = f"file.{domain}"
+
+        # Rewrite direct pawchive.<suffix> URLs to file.pawchive.<suffix>.
+        if parsed.netloc == domain:
+            parsed = parsed._replace(netloc=pawchive_file_host)
+        elif parsed.netloc.startswith(f"{domain}:"):
+            parsed = parsed._replace(netloc=parsed.netloc.replace(domain, pawchive_file_host, 1))
+
+        # For pawchive domains, the file path must contain /data/.
         path = parsed.path
         if not path.startswith("/data/"):
             cleaned_path = "/data/" + path.lstrip("/")
             parsed = parsed._replace(path=cleaned_path)
-            full_url = urlunparse(parsed)
+
+        full_url = urlunparse(parsed)
 
     return full_url
 

--- a/src/kemonodownloader/domain_config.py
+++ b/src/kemonodownloader/domain_config.py
@@ -163,7 +163,9 @@ def clean_file_url(file_url: str, domain_config: Dict[str, str]) -> str:
         if parsed.netloc == domain:
             parsed = parsed._replace(netloc=pawchive_file_host)
         elif parsed.netloc.startswith(f"{domain}:"):
-            parsed = parsed._replace(netloc=parsed.netloc.replace(domain, pawchive_file_host, 1))
+            parsed = parsed._replace(
+                netloc=parsed.netloc.replace(domain, pawchive_file_host, 1)
+            )
 
         # For pawchive domains, the file path must contain /data/.
         path = parsed.path

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -321,58 +321,59 @@ class TestCleanFileUrl:
         assert url == "https://kemono.cr/data/123.png"
 
     def test_pawchive_relative_url(self):
-        """Test pawchive.st relative path uses file.pawchive.st."""
+        """Test pawchive relative path uses file.pawchive.<suffix>."""
         from kemonodownloader.domain_config import clean_file_url
 
         domain_config = {
-            "domain": "pawchive.st",
-            "base_url": "https://pawchive.st",
-            "file_base_url": "https://file.pawchive.st",
+            "domain": "pawchive.pw",
+            "base_url": "https://pawchive.pw",
+            "file_base_url": "https://file.pawchive.pw",
         }
         url = clean_file_url("/data/123.png", domain_config)
-        assert url == "https://file.pawchive.st/data/123.png"
+        assert url == "https://file.pawchive.pw/data/123.png"
 
     def test_pawchive_absolute_url(self):
-        """Test pawchive.st absolute path is rewritten to file.pawchive.st."""
+        """Test pawchive absolute path is rewritten to file.pawchive.<suffix>."""
         from kemonodownloader.domain_config import clean_file_url
 
         domain_config = {
-            "domain": "pawchive.st",
-            "base_url": "https://pawchive.st",
-            "file_base_url": "https://file.pawchive.st",
+            "domain": "pawchive.pw",
+            "base_url": "https://pawchive.pw",
+            "file_base_url": "https://file.pawchive.pw",
         }
-        url = clean_file_url("https://pawchive.st/data/123.png", domain_config)
-        assert url == "https://file.pawchive.st/data/123.png"
+        url = clean_file_url("https://pawchive.pw/data/123.png", domain_config)
+        assert url == "https://file.pawchive.pw/data/123.png"
 
     def test_pawchive_domain_config_has_file_base_url(self):
-        """Test that get_domain_config for pawchive returns correct file_base_url."""
-        from kemonodownloader.domain_config import get_domain_config
+        """Test that get_domain_config for pawchive returns suffix-matched file_base_url."""
+        from kemonodownloader.domain_config import get_domain_config, get_domains
 
-        config = get_domain_config("https://pawchive.st/patreon/user/123")
-        assert config["domain"] == "pawchive.st"
-        assert config["base_url"] == "https://pawchive.st"
-        assert config["file_base_url"] == "https://file.pawchive.st"
+        pawchive_domain = next(d for d in get_domains() if d.startswith("pawchive."))
+        config = get_domain_config(f"https://{pawchive_domain}/patreon/user/123")
+        assert config["domain"] == pawchive_domain
+        assert config["base_url"] == f"https://{pawchive_domain}"
+        assert config["file_base_url"] == f"https://file.{pawchive_domain}"
 
     def test_pawchive_relative_url_missing_data(self):
-        """Test pawchive.st relative path without /data/ gets /data/ prepended."""
+        """Test pawchive relative path without /data/ gets /data/ prepended."""
         from kemonodownloader.domain_config import clean_file_url
 
         domain_config = {
-            "domain": "pawchive.st",
-            "base_url": "https://pawchive.st",
-            "file_base_url": "https://file.pawchive.st",
+            "domain": "pawchive.pw",
+            "base_url": "https://pawchive.pw",
+            "file_base_url": "https://file.pawchive.pw",
         }
         url = clean_file_url("/35/c3/123.png", domain_config)
-        assert url == "https://file.pawchive.st/data/35/c3/123.png"
+        assert url == "https://file.pawchive.pw/data/35/c3/123.png"
 
     def test_pawchive_absolute_url_missing_data(self):
-        """Test pawchive.st absolute path without /data/ gets /data/ prepended and rewritten."""
+        """Test pawchive absolute path without /data/ gets /data/ prepended and rewritten."""
         from kemonodownloader.domain_config import clean_file_url
 
         domain_config = {
-            "domain": "pawchive.st",
-            "base_url": "https://pawchive.st",
-            "file_base_url": "https://file.pawchive.st",
+            "domain": "pawchive.pw",
+            "base_url": "https://pawchive.pw",
+            "file_base_url": "https://file.pawchive.pw",
         }
-        url = clean_file_url("https://pawchive.st/35/c3/123.png", domain_config)
-        assert url == "https://file.pawchive.st/data/35/c3/123.png"
+        url = clean_file_url("https://pawchive.pw/35/c3/123.png", domain_config)
+        assert url == "https://file.pawchive.pw/data/35/c3/123.png"


### PR DESCRIPTION
Add dynamic handling for pawchive.<suffix> domains: detect pawchive.* hosts, build file_base_url as file.pawchive.<suffix>, and rewrite/normalize file URLs (including ensuring /data/ path). Update fallback domain to pawchive.pw, bump app and packaging version to v5.11.1, refresh README and CHANGELOG, and adjust tests to be suffix-agnostic.